### PR TITLE
Update for Stardew Valley 1.3.32 and the upcoming SMAPI 3.0

### DIFF
--- a/ContentInjector.cs
+++ b/ContentInjector.cs
@@ -3,11 +3,6 @@ using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
 using StardewValley;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CustomCrops
 {

--- a/CustomCrops.csproj
+++ b/CustomCrops.csproj
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
-  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/CustomCrops.csproj
+++ b/CustomCrops.csproj
@@ -53,8 +53,8 @@
     <None Include="manifest.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="1.7.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CustomCrops.csproj
+++ b/CustomCrops.csproj
@@ -14,8 +14,6 @@
     <AssemblyName>CustomCrops</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,10 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -57,14 +51,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="1.7.1" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/Mod.cs
+++ b/Mod.cs
@@ -1,33 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using StardewModdingAPI;
 using System.IO;
-using System.Reflection;
-using StardewModdingAPI.Events;
-using StardewValley.Menus;
 using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
 using StardewValley;
+using StardewValley.Menus;
 
 namespace CustomCrops
 {
     public class Mod : StardewModdingAPI.Mod
     {
         public static Mod instance;
-        
+
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
             instance = this;
 
-            MenuEvents.MenuChanged += menuChanged;
+            helper.Events.Display.MenuChanged += OnMenuChanged;
 
-            var savedIds = helper.ReadJsonFile<Dictionary<string, CropData.Ids>>(Path.Combine(Helper.DirectoryPath, "saved-ids.json"));
+            var savedIds = helper.Data.ReadJsonFile<Dictionary<string, CropData.Ids>>("saved-ids.json");
             if (savedIds != null)
             {
                 CropData.savedIds = savedIds;
-                foreach ( var ids in savedIds )
+                foreach (var ids in savedIds)
                 {
                     CropData.Ids.MostRecentObject = Math.Max(CropData.Ids.MostRecentObject, Math.Max(ids.Value.Product, ids.Value.Seeds));
                     CropData.Ids.MostRecentCrop = Math.Max(CropData.Ids.MostRecentCrop, ids.Value.Crop);
@@ -36,67 +34,68 @@ namespace CustomCrops
 
             CropData.crops.Clear();
             Log.info("Registering custom crops...");
-            foreach (var file in Directory.EnumerateDirectories(Path.Combine(helper.DirectoryPath, "Crops")))
+            foreach (var folderPath in Directory.EnumerateDirectories(Path.Combine(helper.DirectoryPath, "Crops")))
             {
+                IContentPack contentPack = this.Helper.ContentPacks.CreateFake(folderPath);
                 try
                 {
-                    var data = helper.ReadJsonFile<CropData>(Path.Combine(file, "crop.json"));
+                    var data = contentPack.ReadJsonFile<CropData>("crop.json");
                     if (data == null)
                     {
-                        Log.warn("\tFailed to load crop data for " + file);
+                        Log.warn($"\tFailed to load crop data for {folderPath}");
                         continue;
                     }
-                    else if (!File.Exists(Path.Combine(file, "crop.png")))
+                    else if (!File.Exists(Path.Combine(folderPath, "crop.png")))
                     {
-                        Log.warn("\tCrop " + file + " has no crop image, skipping");
+                        Log.warn($"\tCrop {folderPath} has no crop image, skipping");
                         continue;
                     }
-                    else if (!File.Exists(Path.Combine(file, "product.png")))
+                    else if (!File.Exists(Path.Combine(folderPath, "product.png")))
                     {
-                        Log.warn("\tCrop " + file + " has no product image, skipping");
+                        Log.warn($"\tCrop {folderPath} has no product image, skipping");
                         continue;
                     }
-                    else if (!File.Exists(Path.Combine(file, "seeds.png")))
+                    else if (!File.Exists(Path.Combine(folderPath, "seeds.png")))
                     {
-                        Log.warn("\tCrop " + file + " has no seeds image, skipping");
+                        Log.warn($"\tCrop {folderPath} has no seeds image, skipping");
                         continue;
                     }
 
-                    Log.info("\tCrop: " + data.Id);
+                    Log.info($"\tCrop: {data.Id}");
                     CropData.Register(data);
                 }
-                catch ( Exception e )
+                catch (Exception e)
                 {
-                    Log.warn("\tFailed to load crop data for " + file + ": " + e );
+                    Log.warn($"\tFailed to load crop data for {folderPath}: {e}");
                     continue;
                 }
             }
-            helper.WriteJsonFile(Path.Combine(Helper.DirectoryPath, "saved-ids.json"), CropData.savedIds);
-
-            var editors = ((IList<IAssetEditor>)helper.Content.GetType().GetProperty("AssetEditors", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance).GetValue(Helper.Content));
-            editors.Add(new ContentInjector());
+            helper.Data.WriteJsonFile("saved-ids.json", CropData.savedIds);
+            helper.Content.AssetEditors.Add(new ContentInjector());
         }
 
-        private void menuChanged(object sender, EventArgsClickableMenuChanged args)
+        /// <summary>Raised after a game menu is opened, closed, or replaced.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void OnMenuChanged(object sender, MenuChangedEventArgs e)
         {
-            var menu = args.NewMenu as ShopMenu;
-            if (menu == null || menu.portraitPerson == null)
+            var menu = e.NewMenu as ShopMenu;
+            if (menu?.portraitPerson == null)
                 return;
 
-            if (menu.portraitPerson.name == "Pierre")
+            if (menu.portraitPerson.Name == "Pierre")
             {
                 Log.trace("Adding crops to shop");
 
-                var forSale = Helper.Reflection.GetPrivateValue<List<Item>>(menu, "forSale");
-                var itemPriceAndStock = Helper.Reflection.GetPrivateValue<Dictionary<Item, int[]>>(menu, "itemPriceAndStock");
+                List<Item> forSale = Helper.Reflection.GetField<List<Item>>(menu, "forSale").GetValue();
+                Dictionary<Item, int[]> itemPriceAndStock = Helper.Reflection.GetField<Dictionary<Item, int[]>>(menu, "itemPriceAndStock").GetValue();
 
-                var precondMeth = Helper.Reflection.GetPrivateMethod(Game1.currentLocation, "checkEventPrecondition");
-                foreach (var crop in CropData.crops)
+                IReflectedMethod precondMeth = Helper.Reflection.GetMethod(Game1.currentLocation, "checkEventPrecondition");
+                foreach (KeyValuePair<string, CropData> crop in CropData.crops)
                 {
                     if (!crop.Value.Seasons.Contains(Game1.currentSeason))
                         continue;
-                    if (crop.Value.SeedPurchaseRequirements.Count > 0 &&
-                        precondMeth.Invoke<int>(new object[] { crop.Value.GetSeedPurchaseRequirementString() }) == -1)
+                    if (crop.Value.SeedPurchaseRequirements.Count > 0 && precondMeth.Invoke<int>(new object[] { crop.Value.GetSeedPurchaseRequirementString() }) == -1)
                         continue;
                     Item item = new StardewValley.Object(Vector2.Zero, crop.Value.GetSeedId(), int.MaxValue);
                     forSale.Add(item);

--- a/Mod.cs
+++ b/Mod.cs
@@ -34,7 +34,10 @@ namespace CustomCrops
 
             CropData.crops.Clear();
             Log.info("Registering custom crops...");
-            foreach (var folderPath in Directory.EnumerateDirectories(Path.Combine(helper.DirectoryPath, "Crops")))
+            DirectoryInfo cropsFolder = new DirectoryInfo(Path.Combine(helper.DirectoryPath, "Crops"));
+            if (!cropsFolder.Exists)
+                cropsFolder.Create();
+            foreach (var folderPath in Directory.EnumerateDirectories(cropsFolder.FullName))
             {
                 IContentPack contentPack = this.Helper.ContentPacks.CreateFake(folderPath);
                 try

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Custom Crops",
   "Author": "spacechase0",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 1,
-    "PatchVersion": 0,
-    "Build": ""
-  },
+  "Version": "1.1.0",
   "Description": "Allow custom crops.",
   "UniqueID": "spacechase0.CustomCrops",
-  "PerSaveConfigs": false,
-  "EntryDll": "CustomCrops.dll"
+  "MinimumApiVersion": "2.9.0",
+  "EntryDll": "CustomCrops.dll",
+  "UpdateKeys": [ "Nexus:1592" ]
 }

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
This pull request...

* Updates the code for compatibility with Stardew Valley 1.3.32 and the upcoming SMAPI 3.0 (still compatible with current versions of SMAPI).
* Updates the mod build package and simplifies the build settings.
* Migrates to the new package reference format.
* Fixes an error if the `Crops` subfolder doesn't exist.

I realise Custom Crops is discontinued, so I don't expect you to release an update. I just updated it since I'm in the code anyway to update your other mods. :)